### PR TITLE
cleaned up the song json passed both to app and admin

### DIFF
--- a/app/assets/javascripts/components/SongApp.jsx
+++ b/app/assets/javascripts/components/SongApp.jsx
@@ -6,6 +6,7 @@ class SongApp extends React.Component {
       settings: this.getSettings()
     }
 
+    // bind all methods to this context (so we can use them)
     this.getSettings = this.getSettings.bind(this);
     this.setSettings = this.setSettings.bind(this);
     this.toggleSettingsPage = this.toggleSettingsPage.bind(this);
@@ -16,6 +17,7 @@ class SongApp extends React.Component {
     this.getLanguages = this.getLanguages.bind(this);
     this.getLanguageCounts = this.getLanguageCounts.bind(this);
 
+    // setup history so users can navigate via browser
     if(this.state.page == 'index') {
       window.history.replaceState({page: 'index'}, '', '/');
     } else {
@@ -23,6 +25,7 @@ class SongApp extends React.Component {
     }
   }
 
+  // when user clicks "back" in their browser, navigate to previous song
   componentDidMount() {
     window.addEventListener("popstate", this.setSongFromHistory);
   }
@@ -72,7 +75,7 @@ class SongApp extends React.Component {
   getSong(id) {
     songs = this.props.songData;
     for(var i=0; i < songs.length; i++){
-      if(songs[i].model.id == id) {
+      if(songs[i].id == id) {
         return songs[i];
       }
     }
@@ -82,14 +85,14 @@ class SongApp extends React.Component {
   // get a list of unique languages in the db
   getLanguages() {
     songs = this.props.songData;
-    return songs.map(s => s.model.lang).filter((v, i, a) => a.indexOf(v) === i).sort();
+    return songs.map(s => s.lang).filter((v, i, a) => a.indexOf(v) === i).sort();
   }
 
   // get a count of the languages in the db
   getLanguageCounts() {
     counts = {};
     songs = this.props.songData;
-    langs = songs.map(s => s.model.lang).forEach(l => counts[l] = (counts[l] || 0) + 1);
+    langs = songs.map(s => s.lang).forEach(l => counts[l] = (counts[l] || 0) + 1);
 
     return counts;
   }
@@ -114,7 +117,7 @@ class SongApp extends React.Component {
         content = <UserSettings languages={this.getLanguages()} languageCounts={this.getLanguageCounts()} setSettings={this.setSettings} settings={this.state.settings} toggleSettingsPage={this.toggleSettingsPage}/>
         break;
       default:
-        content = <SongDisplay lyrics={ this.getSong(page).model.lyrics } />
+        content = <SongDisplay lyrics={ this.getSong(page).lyrics } />
     }
     return(
       <div className="song-app">

--- a/app/assets/javascripts/components/SongIndex.jsx.erb
+++ b/app/assets/javascripts/components/SongIndex.jsx.erb
@@ -24,7 +24,7 @@ class SongIndex extends React.Component {
 
     // filter songs by language settings
     songs = songs.filter(function(song) {
-      return this.props.settings.languages.includes(song.model.lang);
+      return this.props.settings.languages.includes(song.lang);
     }, this);
 
     var indexMatch = songs.filter(function(song) {
@@ -44,7 +44,7 @@ class SongIndex extends React.Component {
 
     var lyricsMatchRegex = new RegExp(strippedSearch, 'i');
     var lyricsMatch = songs.filter(function (song) {
-      return lyricsMatchRegex.test(this.stripString(song.model.lyrics));
+      return lyricsMatchRegex.test(this.stripString(song.lyrics));
     }, this);
 
     searchResults = indexMatch.concat(titleStart).concat(titleMatch).concat(lyricsMatch);
@@ -78,7 +78,7 @@ class SongIndex extends React.Component {
         </div>
         <div className="title-list pure-u-1-1">
           {this.filterSongs().map(function(obj, i){
-            return <div className="index_row" key={i} id={obj.model.id} onClick={this.props.setSong}>{obj.title}</div>;
+            return <div className="index_row" key={i} id={obj.id} onClick={this.props.setSong}>{obj.title}</div>;
           }, this)}
         </div>
 

--- a/app/views/songs/_admin_songs.html.erb
+++ b/app/views/songs/_admin_songs.html.erb
@@ -1,12 +1,12 @@
 <% songs.each do |song| %>
   <tr>
-    <td><%= link_to song[:title], edit_song_path(song[:model]), class: "wash-link edit_song_link", id: (review_changed ? "req_review_changed" : review_duplicate ? "req_review_duplicate" : nil) %></td>
+    <td><%= link_to song[:title], edit_song_path(song[:id]), class: "wash-link edit_song_link", id: (review_changed ? "req_review_changed" : review_duplicate ? "req_review_duplicate" : nil) %></td>
 
     <% if super_admin %>
-      <td><%= link_to 'Remove', song[:model], method: :delete, data: { confirm: 'Are you sure?' }, class: "wash-link remove_song_link" %></td>
+      <td><%= link_to 'Remove', song_path(song[:id]), method: :delete, data: { confirm: 'Are you sure?' }, class: "wash-link remove_song_link" %></td>
     <% end %>
 
-    <td><div class="last_edited"><%= (super_admin ? '' : "last edited by: ") + (song[:model][:last_editor] || 'System') %></div></td>
+    <td><div class="last_edited"><%= (super_admin ? '' : "last edited by: ") + (song[:last_editor] || 'System') %></div></td>
 
     <% if song[:edit_timestamp] %>
       <td><div class="edit_timestamp"><%= time_ago_in_words(song[:edit_timestamp]) %> ago</div></td>

--- a/app/views/songs/admin.html.erb
+++ b/app/views/songs/admin.html.erb
@@ -8,7 +8,9 @@
     <tr>
       <%= link_to 'New Song', new_song_path, class: "new_song_link" %>
     </tr>
-    <%= render partial: 'admin_songs', locals: {songs: @songs_to_check[:duplicates], review_changed: false, review_duplicate: true} %>
+    <% if super_admin %>
+      <%= render partial: 'admin_songs', locals: {songs: @songs_to_check[:duplicates], review_changed: false, review_duplicate: true} %>
+    <% end %>
     <%= render partial: 'admin_songs', locals: {songs: @songs_to_check[:changed], review_changed: true, review_duplicate: false} %>
     <%= render partial: 'admin_songs', locals: {songs: @songs, review_changed: false, review_duplicate: false} %>
   </tbody>


### PR DESCRIPTION
Big PR:

- A couple of refactors n comments, so the code is cleaner and easier to understand.
- Removed `model` from the song entries. All necessary attributes are on a flat array, and unused attributes have been cut from app and admin song lists.
- Separate lists for admin and app, since they need different attributes.
- Turned duplicates algorithm into a scope, and added "within 3 months" so old and consciously ignored duplicates wont show forever.
- Only super admins can see duplicates (since only they can remove songs anyway).

## UI
![image](https://user-images.githubusercontent.com/2679248/37748146-9909acac-2de7-11e8-8759-a9b35a4d52a5.png)
